### PR TITLE
add no-trailing-spaces rule

### DIFF
--- a/javascript/.eslintrc
+++ b/javascript/.eslintrc
@@ -25,6 +25,7 @@
     "space-before-function-paren": 0,
     "brace-style": ["error", "1tbs"],
     "import/prefer-default-export": "off",
-    "linebreak-style": "off"
+    "linebreak-style": "off",
+    "no-trailing-spaces": ["error", {"skipBlankLines": true, "ignoreComments": true}]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fd-styleguide",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A styleguide and tools to enforce it.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
I'd like to add this rule to our JS styleguide:

`"no-trailing-spaces": ["error", {"skipBlankLines": true, "ignoreComments": true}]`

see https://eslint.org/docs/rules/no-trailing-spaces

Why do I want to add this? Because per default, I need to write my code really compact:

```
/**
 * a description for this function
 * @param {string} bar - description of the parameter bar
 */
function foo(bar) {
    if (condition) {
      // do something
    }
    continueToDoSomething();
}
```

But I would like to be able to let my code breathe and structure it in blocks where needed:

```
/**
 * a description for this function
 * 
 * @param {string} bar - description of the parameter bar
 */
function foo(bar) {
    
    if (condition) {
      // do something
    }
    
    continueToDoSomething();
}
```

As for the `skipBlankLines` option, please notice that the empty lines in my examples do contain spaces. I can't tell IntelliJ to not automatically use such indentation on empty lines.

I hope this is understandable?